### PR TITLE
POS-1952 Tinyproxy improvements

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ tinyproxy_group: "nogroup"
 tinyproxy_port: "8888"
 
 tinyproxy_listen: "0.0.0.0"
-tinyproxy_timeout: 30
+tinyproxy_timeout: 60
 tinyproxy_statfile: "/usr/share/tinyproxy/stats.html"
 tinyproxy_logfile: "/var/log/tinyproxy/tinyproxy.log"
 tinyproxy_loglevel: "Error"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,12 +4,12 @@ tinyproxy_group: "nogroup"
 tinyproxy_port: "8888"
 
 tinyproxy_listen: "0.0.0.0"
-tinyproxy_timeout: 600
+tinyproxy_timeout: 30
 tinyproxy_statfile: "/usr/share/tinyproxy/stats.html"
 tinyproxy_logfile: "/var/log/tinyproxy/tinyproxy.log"
-tinyproxy_loglevel: "Info"
+tinyproxy_loglevel: "Error"
 tinyproxy_pidfile: "/var/run/tinyproxy/tinyproxy.pid"
-tinyproxy_maxclient: 100
+tinyproxy_maxclient: 5000
 tinyproxy_minSpareServers: 10
 tinyproxy_maxSpareServers: 20
 tinyproxy_startServers: 10

--- a/templates/tinyproxy.conf.j2
+++ b/templates/tinyproxy.conf.j2
@@ -78,7 +78,7 @@ DefaultErrorFile "/usr/share/tinyproxy/default.html"
 # forwarding the request to that host.  The default value of StatHost is
 # tinyproxy.stats.
 #
-#StatHost "tinyproxy.stats"
+StatHost "tinyproxy.stats"
 #
 
 #

--- a/templates/tinyproxy.conf.j2
+++ b/templates/tinyproxy.conf.j2
@@ -78,7 +78,7 @@ DefaultErrorFile "/usr/share/tinyproxy/default.html"
 # forwarding the request to that host.  The default value of StatHost is
 # tinyproxy.stats.
 #
-StatHost "tinyproxy.stats"
+#StatHost "tinyproxy.stats"
 #
 
 #


### PR DESCRIPTION
🚀 Performance Tuning
Reduced tinyproxy_timeout: Dropped from 600s to 60s. This ensures that idle or "hung" connections are reaped much faster, freeing up slots for active users.

Increased tinyproxy_maxclient: Scaled significantly from 100 to 5000. This allows the service to support a much larger number of simultaneous connections, suitable for larger environments.

🧹 Maintenance & Logging
Adjusted tinyproxy_loglevel: Switched from Info to Error. This will drastically reduce log "noise" and disk I/O, ensuring the log files only contain actionable issues rather than standard connection breadcrumbs.